### PR TITLE
Correctly report `ModifiersChanged` on losing/focus

### DIFF
--- a/src/platform_impl/web/web_sys/canvas/mouse_handler.rs
+++ b/src/platform_impl/web/web_sys/canvas/mouse_handler.rs
@@ -2,13 +2,14 @@ use super::event;
 use super::EventListenerHandle;
 use crate::dpi::PhysicalPosition;
 use crate::event::MouseButton;
+use crate::keyboard::ModifiersState;
 
 use std::cell::RefCell;
 use std::rc::Rc;
 
 use web_sys::{EventTarget, MouseEvent};
 
-type MouseLeaveHandler = Rc<RefCell<Option<Box<dyn FnMut(i32)>>>>;
+type MouseLeaveHandler = Rc<RefCell<Option<Box<dyn FnMut(i32, ModifiersState)>>>>;
 
 #[allow(dead_code)]
 pub(super) struct MouseHandler {
@@ -42,40 +43,48 @@ impl MouseHandler {
     }
     pub fn on_cursor_leave<F>(&mut self, canvas_common: &super::Common, handler: F)
     where
-        F: 'static + FnMut(i32),
+        F: 'static + FnMut(i32, ModifiersState),
     {
         *self.on_mouse_leave_handler.borrow_mut() = Some(Box::new(handler));
         let on_mouse_leave_handler = self.on_mouse_leave_handler.clone();
         let mouse_capture_state = self.mouse_capture_state.clone();
-        self.on_mouse_leave = Some(canvas_common.add_event("mouseout", move |_: MouseEvent| {
-            // If the mouse is being captured, it is always considered
-            // to be "within" the the canvas, until the capture has been
-            // released, therefore we don't send cursor leave events.
-            if *mouse_capture_state.borrow() != MouseCaptureState::Captured {
-                if let Some(handler) = on_mouse_leave_handler.borrow_mut().as_mut() {
-                    handler(0);
+        self.on_mouse_leave = Some(canvas_common.add_event(
+            "mouseout",
+            move |event: MouseEvent| {
+                // If the mouse is being captured, it is always considered
+                // to be "within" the the canvas, until the capture has been
+                // released, therefore we don't send cursor leave events.
+                if *mouse_capture_state.borrow() != MouseCaptureState::Captured {
+                    if let Some(handler) = on_mouse_leave_handler.borrow_mut().as_mut() {
+                        let modifiers = event::mouse_modifiers(&event);
+                        handler(0, modifiers);
+                    }
                 }
-            }
-        }));
+            },
+        ));
     }
 
     pub fn on_cursor_enter<F>(&mut self, canvas_common: &super::Common, mut handler: F)
     where
-        F: 'static + FnMut(i32),
+        F: 'static + FnMut(i32, ModifiersState),
     {
         let mouse_capture_state = self.mouse_capture_state.clone();
-        self.on_mouse_enter = Some(canvas_common.add_event("mouseover", move |_: MouseEvent| {
-            // We don't send cursor leave events when the mouse is being
-            // captured, therefore we do the same with cursor enter events.
-            if *mouse_capture_state.borrow() != MouseCaptureState::Captured {
-                handler(0);
-            }
-        }));
+        self.on_mouse_enter = Some(canvas_common.add_event(
+            "mouseover",
+            move |event: MouseEvent| {
+                // We don't send cursor leave events when the mouse is being
+                // captured, therefore we do the same with cursor enter events.
+                if *mouse_capture_state.borrow() != MouseCaptureState::Captured {
+                    let modifiers = event::mouse_modifiers(&event);
+                    handler(0, modifiers);
+                }
+            },
+        ));
     }
 
     pub fn on_mouse_release<F>(&mut self, canvas_common: &super::Common, mut handler: F)
     where
-        F: 'static + FnMut(i32, MouseButton),
+        F: 'static + FnMut(i32, MouseButton, ModifiersState),
     {
         let on_mouse_leave_handler = self.on_mouse_leave_handler.clone();
         let mouse_capture_state = self.mouse_capture_state.clone();
@@ -99,7 +108,8 @@ impl MouseHandler {
                     MouseCaptureState::Captured => {}
                 }
                 event.stop_propagation();
-                handler(0, event::mouse_button(&event));
+                let modifiers = event::mouse_modifiers(&event);
+                handler(0, event::mouse_button(&event), modifiers);
                 if event
                     .target()
                     .map_or(false, |target| target != EventTarget::from(canvas))
@@ -108,7 +118,8 @@ impl MouseHandler {
                     // cursor is being captured, we instead send it after
                     // the capture has been released.
                     if let Some(handler) = on_mouse_leave_handler.borrow_mut().as_mut() {
-                        handler(0);
+                        let modifiers = event::mouse_modifiers(&event);
+                        handler(0, modifiers);
                     }
                 }
                 if event.buttons() == 0 {
@@ -122,7 +133,7 @@ impl MouseHandler {
 
     pub fn on_mouse_press<F>(&mut self, canvas_common: &super::Common, mut handler: F)
     where
-        F: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton, ModifiersState),
     {
         let mouse_capture_state = self.mouse_capture_state.clone();
         let canvas = canvas_common.raw.clone();
@@ -147,10 +158,12 @@ impl MouseHandler {
                 }
                 *mouse_capture_state = MouseCaptureState::Captured;
                 event.stop_propagation();
+                let modifiers = event::mouse_modifiers(&event);
                 handler(
                     0,
                     event::mouse_position(&event).to_physical(super::super::scale_factor()),
                     event::mouse_button(&event),
+                    modifiers,
                 );
             },
         ));
@@ -158,7 +171,7 @@ impl MouseHandler {
 
     pub fn on_cursor_move<F>(&mut self, canvas_common: &super::Common, mut handler: F)
     where
-        F: 'static + FnMut(i32, PhysicalPosition<f64>, PhysicalPosition<f64>),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, PhysicalPosition<f64>, ModifiersState),
     {
         let mouse_capture_state = self.mouse_capture_state.clone();
         let canvas = canvas_common.raw.clone();
@@ -189,10 +202,12 @@ impl MouseHandler {
                             event::mouse_position_by_client(&event, &canvas)
                         };
                         let mouse_delta = event::mouse_delta(&event);
+                        let modifiers = event::mouse_modifiers(&event);
                         handler(
                             0,
                             mouse_pos.to_physical(super::super::scale_factor()),
                             mouse_delta.to_physical(super::super::scale_factor()),
+                            modifiers,
                         );
                     }
                 }

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -89,14 +89,42 @@ pub fn key_location(event: &KeyboardEvent) -> KeyLocation {
     }
 }
 
-pub fn keyboard_modifiers(key: &Key) -> ModifiersState {
-    match key {
-        Key::Shift => ModifiersState::SHIFT,
-        Key::Control => ModifiersState::CONTROL,
-        Key::Alt => ModifiersState::ALT,
-        Key::Super => ModifiersState::SUPER,
-        _ => ModifiersState::empty(),
+pub fn keyboard_modifiers(event: &KeyboardEvent) -> ModifiersState {
+    let mut state = ModifiersState::empty();
+
+    if event.shift_key() {
+        state |= ModifiersState::SHIFT;
     }
+    if event.ctrl_key() {
+        state |= ModifiersState::CONTROL;
+    }
+    if event.alt_key() {
+        state |= ModifiersState::ALT;
+    }
+    if event.meta_key() {
+        state |= ModifiersState::SUPER;
+    }
+
+    state
+}
+
+pub fn mouse_modifiers(event: &MouseEvent) -> ModifiersState {
+    let mut state = ModifiersState::empty();
+
+    if event.shift_key() {
+        state |= ModifiersState::SHIFT;
+    }
+    if event.ctrl_key() {
+        state |= ModifiersState::CONTROL;
+    }
+    if event.alt_key() {
+        state |= ModifiersState::ALT;
+    }
+    if event.meta_key() {
+        state |= ModifiersState::SUPER;
+    }
+
+    state
 }
 
 pub fn touch_position(event: &PointerEvent, _canvas: &HtmlCanvasElement) -> LogicalPosition<f64> {

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -11,7 +11,7 @@ use raw_window_handle::{RawDisplayHandle, RawWindowHandle, WebDisplayHandle, Web
 
 use super::{backend, monitor::MonitorHandle, EventLoopWindowTarget, Fullscreen};
 
-use std::cell::{Ref, RefCell};
+use std::cell::{Cell, Ref, RefCell};
 use std::collections::vec_deque::IntoIter as VecDequeIter;
 use std::collections::VecDeque;
 use std::rc::Rc;
@@ -23,7 +23,7 @@ pub struct Window {
     register_redraw_request: Box<dyn Fn()>,
     resize_notify_fn: Box<dyn Fn(PhysicalSize<u32>)>,
     destroy_fn: Option<Box<dyn FnOnce()>>,
-    has_focus: Rc<RefCell<bool>>,
+    has_focus: Rc<Cell<bool>>,
 }
 
 impl Window {
@@ -43,7 +43,7 @@ impl Window {
 
         let register_redraw_request = Box::new(move || runner.request_redraw(RootWI(id)));
 
-        let has_focus = Rc::new(RefCell::new(false));
+        let has_focus = Rc::new(Cell::new(false));
         target.register(&canvas, id, prevent_default, has_focus.clone());
 
         let runner = target.runner.clone();
@@ -388,7 +388,7 @@ impl Window {
 
     #[inline]
     pub fn has_focus(&self) -> bool {
-        *self.has_focus.borrow()
+        self.has_focus.get()
     }
 
     pub fn title(&self) -> String {


### PR DESCRIPTION
## Changes

- When losing focus, we report no active modifiers with `ModifiersChanged`.
- When regaining focus, we can't determine which modifiers are currently active, but we can deduce it from keyboard and mouse events. If focusing happens to coincide with any of those events, it will show up exactly how it does on native.
- Store `has_focus` in `Cell` instead of `RefCell`, it's just a `bool`.

## Failed Solution 1

Why we don't "track" modifiers over keyboard and mouse events while the window isn't in focus?
The problem starts with some terminology inconsistencies, a Winit window is usually what a OS describes as a window. That is not the case for Web, on Web a window is just a canvas. We could track mouse events and even keyboard events while the canvas isn't in focus, but not when the actual browser window is not in focus. If we track modifiers while the canvas isn't in focus but the browser window is, modifiers could change while the browser window isn't in focus and we would get stuck modifiers.

## Failed Solution 2

Trying to resolve the solution outlined above, we could track modifiers while the canvas isn't in focus but the browser window is, but clear modifiers if the browser window loses focus to avoid getting modifiers stuck when the window loses focus. Unfortunately this doesn't really provide any advantage, because the only way a canvas can regain focus without having lost the browser window focus is with a keyboard or mouse event (unless you do it over scripting, which is becoming increasingly insane).

## Conclusion

I wish I could explain any of this better, but this is all very convoluted and the Web APIs are quite complicated.

The conclusion is that there is really no perfect way to have a correct modifier state when regaining the browser window focus, we will have to wait until we get a keyboard or mouse event.